### PR TITLE
track the section of the pipfile from where the dependency originated

### DIFF
--- a/dparse/dependencies.py
+++ b/dparse/dependencies.py
@@ -11,7 +11,7 @@ class Dependency(object):
 
     """
 
-    def __init__(self, name, specs, line, source="pypi", meta={}, extras=[], line_numbers=None, index_server=None, hashes=(), dependency_type=None):
+    def __init__(self, name, specs, line, source="pypi", meta={}, extras=[], line_numbers=None, index_server=None, hashes=(), dependency_type=None, section=None):
         """
 
         :param name:
@@ -35,6 +35,7 @@ class Dependency(object):
         self.hashes = hashes
         self.dependency_type = dependency_type
         self.extras = extras
+        self.section = section
 
     def __str__(self):  # pragma: no cover
         """
@@ -62,7 +63,8 @@ class Dependency(object):
             "index_server": self.index_server,
             "hashes": self.hashes,
             "dependency_type": self.dependency_type,
-            "extras": self.extras
+            "extras": self.extras,
+            "section": self.section
         }
 
     @classmethod

--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -348,13 +348,12 @@ class PipfileParser(Parser):
                                 continue
                             if specs == '*':
                                 specs = ''
-                            extras = {'package_type': package_type}
                             self.obj.dependencies.append(
                                 Dependency(
                                     name=name, specs=SpecifierSet(specs),
                                     dependency_type=filetypes.pipfile,
                                     line=''.join([name, specs]),
-                                    extras=extras
+                                    section=package_type
                                 )
                             )
         except toml.TomlDecodeError:
@@ -384,7 +383,8 @@ class PipfileLockParser(Parser):
                                     name=name, specs=SpecifierSet(specs),
                                     dependency_type=filetypes.pipfile_lock,
                                     hashes=hashes,
-                                    line=''.join([name, specs])
+                                    line=''.join([name, specs]),
+                                    section=package_type
                                 )
                             )
         except json.JSONDecodeError:

--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -348,11 +348,13 @@ class PipfileParser(Parser):
                                 continue
                             if specs == '*':
                                 specs = ''
+                            extras = {'package_type': package_type}
                             self.obj.dependencies.append(
                                 Dependency(
                                     name=name, specs=SpecifierSet(specs),
                                     dependency_type=filetypes.pipfile,
-                                    line=''.join([name, specs])
+                                    line=''.join([name, specs]),
+                                    extras=extras
                                 )
                             )
         except toml.TomlDecodeError:


### PR DESCRIPTION
For a project where I'd like to use dparse to work with Pipfiles and Pipfile.locks, I'd really like to track the section of the Pipfile from where the dependencies originate.

The use case is that I want to only really care about those dependencies which are "packages", not "dev-packages"  I added a new dependencies attribute to track the data as I couldn't determine a better place to stuff it, thus my modifications below.

Thanks for the dparse library, it's saved me a fair bit of time already.