### PR TITLE
Fix several warnings related to the ConfigParser module

### DIFF
--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -289,7 +289,7 @@ class ToxINIParser(Parser):
         :return:
         """
         parser = ConfigParser()
-        parser.readfp(StringIO(self.obj.content))
+        parser.read_file(StringIO(self.obj.content))
         for section in parser.sections():
             try:
                 content = parser.get(section=section, option="deps")
@@ -394,7 +394,7 @@ class PipfileLockParser(Parser):
 class SetupCfgParser(Parser):
     def parse(self):
         parser = ConfigParser()
-        parser.readfp(StringIO(self.obj.content))
+        parser.read_file(StringIO(self.obj.content))
         for section in parser.values():
             if section.name == 'options':
                 options = 'install_requires', 'setup_requires', 'test_require'

--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -12,9 +12,9 @@ except ImportError:
 
 # Python 2 & 3 compatible Configparser
 try:
-    from ConfigParser import SafeConfigParser, NoOptionError
+    from ConfigParser import ConfigParser, NoOptionError
 except ImportError:
-    from configparser import SafeConfigParser, NoOptionError
+    from configparser import ConfigParser, NoOptionError
 
 # Python 2 & 3 compatible basestring
 try:  # pragma: no cover
@@ -288,7 +288,7 @@ class ToxINIParser(Parser):
 
         :return:
         """
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.readfp(StringIO(self.obj.content))
         for section in parser.sections():
             try:
@@ -393,7 +393,7 @@ class PipfileLockParser(Parser):
 
 class SetupCfgParser(Parser):
     def parse(self):
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.readfp(StringIO(self.obj.content))
         for section in parser.values():
             if section.name == 'options':


### PR DESCRIPTION
Hello,

2 little fixes for deprecated warnings in `parser.py`. I am not sure it will pass Python 2.6, the CI will tell :)

Edit: the CI is dead :/