### PR TITLE
Fix "AttributeError: SafeConfigParser instance has no attribute 'values'"

### DIFF
--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -395,16 +395,15 @@ class SetupCfgParser(Parser):
     def parse(self):
         parser = SafeConfigParser()
         parser.readfp(StringIO(self.obj.content))
-        for section in parser.values():
-            if section.name == 'options':
+        for section in parser.sections():
+            if section == 'options':
                 options = 'install_requires', 'setup_requires', 'test_require'
                 for name in options:
-                    content = section.get(name)
-                    if not content:
-                        continue
-                    self._parse_content(content)
-            elif section.name == 'options.extras_require':
-                for content in section.values():
+                    if parser.has_option('options', name):
+                        content = section.get('options', name)
+                        self._parse_content(content)
+            elif section == 'options.extras_require':
+                for _, content in parser.items('options.extras_require'):
                     self._parse_content(content)
 
     def _parse_content(self, content):


### PR DESCRIPTION
This method simply doesn't exist, and this appears to be a typo. The correct method appears to be `.sections()`; there is similar (correct) code in `ToxINIParser` on L293.

However, the rest of this class seems to not correctly use the `configparser`/`ConfigParser` API correctly at all; I've fixed it to do so.

This should fix — (break to get the GitHub auto-close feature to back off) — https://github.com/pyupio/pyup/issues/294 once `pyup` updates to a new version containing this fix, I hope.

The [relevant section of the documentation for `configparser`](https://docs.python.org/2.7/library/configparser.html#ConfigParser.RawConfigParser.sections).