### PR TITLE
Add support for piptools requirements.in

### DIFF
--- a/dparse/dependencies.py
+++ b/dparse/dependencies.py
@@ -132,7 +132,7 @@ class DependencyFile(object):
                     self.parser = parser_class.SetupCfgParser
 
             elif path is not None:
-                if path.endswith(".txt"):
+                if path.endswith((".txt", ".in")):
                     self.parser = parser_class.RequirementsTXTParser
                 elif path.endswith(".yml"):
                     self.parser = parser_class.CondaYMLParser

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -133,6 +133,9 @@ def test_parser_class():
     dep_file = parse("", path="req.txt")
     assert isinstance(dep_file.parser, parser.RequirementsTXTParser)
 
+    dep_file = parse("", path="req.in")
+    assert isinstance(dep_file.parser, parser.RequirementsTXTParser)
+
     dep_file = parse("", file_type=filetypes.tox_ini)
     assert isinstance(dep_file.parser, parser.ToxINIParser)
 


### PR DESCRIPTION
requirements.in is a file used as an input for piptools requirements
to generate actual requirement with pip-compile

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>