### PR TITLE
Use ConfigParser directly

### DIFF
--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -6,7 +6,7 @@ import yaml
 
 from io import StringIO
 
-from configparser import SafeConfigParser, NoOptionError
+from configparser import ConfigParser, NoOptionError
 
 
 from .regex import URL_REGEX, HASH_REGEX
@@ -274,7 +274,7 @@ class ToxINIParser(Parser):
 
         :return:
         """
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.readfp(StringIO(self.obj.content))
         for section in parser.sections():
             try:
@@ -379,7 +379,7 @@ class PipfileLockParser(Parser):
 
 class SetupCfgParser(Parser):
     def parse(self):
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.readfp(StringIO(self.obj.content))
         for section in parser.values():
             if section.name == 'options':


### PR DESCRIPTION
Apparently SafeConfigParser was renamed to ConfigParser in Python 3.2,
and the old SafeConfigParser name was kept for backward compatibility until Python 3.11.

Note: opening this to see how CI behaves. If it fails due to the changes in this PR,
I'll try to import SafeConfigParser first then ConfigParser if it fails.

Fixes #51