### PR TITLE
Local import YAML instead of top level

### DIFF
--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals, absolute_import
 from collections import OrderedDict
 import re
-import yaml
 
 from io import StringIO
 
@@ -301,6 +300,7 @@ class CondaYMLParser(Parser):
 
         :return:
         """
+        import yaml
         try:
             data = yaml.safe_load(self.obj.content)
             if data and 'dependencies' in data and isinstance(data['dependencies'], list):


### PR DESCRIPTION
Hi!  pipenv maintainer here...

We, @matteius and me, are trying to clean up vendored libraries shipped with pipenv.
I noticed that YAML is only used to parse conda files. If you merge in this patch, it would allow us to drop this
dependency. 

You can also make YAML and optional dependency for your users with:

```
setup(
 name='dparse',
    version='0.5.2a',
    description="A parser for Python dependency files",
    long_description=readme + '\n\n' + history,
   ...
    extras_require={
        'pipenv':  ["pipenv"],
        'conda': ["yaml"],
    }
)
```

However, I didn't submit a patch for this just to limit the scope of this PR.

Thank you very much.

