### PR TITLE
Fix PermissionError when running test_updater.py::test_update_pipfile

### DIFF
--- a/dparse/updater.py
+++ b/dparse/updater.py
@@ -92,7 +92,9 @@ class PipfileUpdater(object):
         pipfile = tempfile.NamedTemporaryFile(delete=False)
         p = Project(chdir=False)
         p.write_toml(data=data, path=pipfile.name)
-        data = open(pipfile.name).read()
+        with open(pipfile.name) as pf:
+            data = pf.read()
+        pipfile.close()
         os.remove(pipfile.name)
         return data
 


### PR DESCRIPTION
Fixes failing tox test:
```
FAILED tests/test_updater.py::test_update_pipfile - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\ptmcg\\AppData\...
```