### PR TITLE
Add minimal pyproject.toml to fix tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add a minimal `pyproject.toml` file that fixes the following `tox` failure:

    ERROR: missing /tmp/dparse/pyproject.toml