### PR TITLE
Use the modern tomli/tomllib to parse TOML files

### DIFF
--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, absolute_import
 import os
 from collections import OrderedDict
 import re
+import sys
 
 from io import StringIO
 
@@ -17,10 +18,14 @@ from .dependencies import DependencyFile, Dependency
 from packaging.requirements import Requirement as PackagingRequirement,\
     InvalidRequirement
 from . import filetypes
-import toml
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version, InvalidVersion
 import json
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 # this is a backport from setuptools 26.1
@@ -356,7 +361,7 @@ class PipfileParser(Parser):
         :return:
         """
         try:
-            data = toml.loads(self.obj.content, _dict=OrderedDict)
+            data = tomllib.loads(self.obj.content)
             if data:
                 for package_type in ['packages', 'dev-packages']:
                     if package_type in data:
@@ -374,7 +379,7 @@ class PipfileParser(Parser):
                                     section=package_type
                                 )
                             )
-        except (toml.TomlDecodeError, IndexError):
+        except (tomllib.TOMLDecodeError, IndexError):
             pass
 
 
@@ -443,7 +448,7 @@ class PoetryLockParser(Parser):
         Parse a poetry.lock
         """
         try:
-            data = toml.loads(self.obj.content, _dict=OrderedDict)
+            data = tomllib.loads(self.obj.content)
             pkg_key = 'package'
             if data:
                 try:
@@ -471,7 +476,7 @@ class PoetryLockParser(Parser):
                             section=section
                         )
                     )
-        except (toml.TomlDecodeError, IndexError) as e:
+        except (tomllib.TOMLDecodeError, IndexError) as e:
             raise MalformedDependencyFileError(info=str(e))
 
 

--- a/dparse/updater.py
+++ b/dparse/updater.py
@@ -3,8 +3,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 import re
 import json
 import tempfile
-import toml
 import os
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 class RequirementsTXTUpdater(object):
@@ -79,7 +84,7 @@ class SetupCFGUpdater(CondaYMLUpdater):
 class PipfileUpdater(object):
     @classmethod
     def update(cls, content, dependency, version, spec="==", hashes=()):
-        data = toml.loads(content)
+        data = tomllib.loads(content)
         if data:
             for package_type in ['packages', 'dev-packages']:
                 if package_type in data:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     "packaging",
-    "toml",
+    "tomli; python_version < '3.11'",
 ]
 
 setup(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,5 +3,5 @@ pyyaml
 pytest
 pytest-cov
 codecov
-toml
+tomli; python_version < "3.11"
 packaging


### PR DESCRIPTION
Replace the unmaintained `toml` package with the modern combination of built-in `tomllib` in Python 3.11+, and its drop-in replacement `tomli` for older Python versions.  This provides full and correct support for TOML 1.0 that `toml` does not provide.  Unfortunately, they do not support overriding dict class but that does not seem to be a major problem, given that TOML tables are not ordered according to the specification.