### PR TITLE
replace ConfigParser's 'readfp' by 'read_string'

### DIFF
--- a/dparse/parser.py
+++ b/dparse/parser.py
@@ -3,8 +3,6 @@ from collections import OrderedDict
 import re
 import sys
 
-from io import StringIO
-
 from configparser import ConfigParser, NoOptionError
 from pathlib import PurePath
 
@@ -305,7 +303,7 @@ class ToxINIParser(Parser):
         :return:
         """
         parser = ConfigParser()
-        parser.readfp(StringIO(self.obj.content))
+        parser.read_string(self.obj.content)
         for section in parser.sections():
             try:
                 content = parser.get(section=section, option="deps")
@@ -413,7 +411,7 @@ class PipfileLockParser(Parser):
 class SetupCfgParser(Parser):
     def parse(self):
         parser = ConfigParser()
-        parser.readfp(StringIO(self.obj.content))
+        parser.read_string(self.obj.content)
         for section in parser.values():
             if section.name == 'options':
                 options = 'install_requires', 'setup_requires', 'test_require'


### PR DESCRIPTION
fixes `DeprecationWarning: This method will be removed in Python 3.12. Use parser.read_file instead`, and will marginally improve performance